### PR TITLE
Keep Bool inline comments

### DIFF
--- a/tests/examples/defaults/from-toml-lang.toml
+++ b/tests/examples/defaults/from-toml-lang.toml
@@ -13,7 +13,7 @@ hosts = [
 server = "192.168.1.1"
 ports = [ 8001, 8001, 8002 ]
 connection_max = 5000
-enabled = true
+enabled = true # Commend after a boolean
 
 [owner]
 name = "Tom Preston-Werner"

--- a/tests/examples/defaults/from-toml-lang.toml
+++ b/tests/examples/defaults/from-toml-lang.toml
@@ -13,7 +13,7 @@ hosts = [
 server = "192.168.1.1"
 ports = [ 8001, 8001, 8002 ]
 connection_max = 5000
-enabled = true # Commend after a boolean
+enabled = true # Comment after a boolean
 
 [owner]
 name = "Tom Preston-Werner"

--- a/tests/examples/from-toml-lang.toml
+++ b/tests/examples/from-toml-lang.toml
@@ -12,7 +12,7 @@ dob = 1979-05-27T07:32:00Z # First class dates? Why not?
 server = "192.168.1.1"
 ports = [ 8001, 8001, 8002 ]
 connection_max = 5000
-enabled = true
+enabled = true # Commend after a boolean
 
 [servers]
 

--- a/tests/examples/from-toml-lang.toml
+++ b/tests/examples/from-toml-lang.toml
@@ -12,7 +12,7 @@ dob = 1979-05-27T07:32:00Z # First class dates? Why not?
 server = "192.168.1.1"
 ports = [ 8001, 8001, 8002 ]
 connection_max = 5000
-enabled = true # Commend after a boolean
+enabled = true # Comment after a boolean
 
 [servers]
 

--- a/toml_sort/tomlsort.py
+++ b/toml_sort/tomlsort.py
@@ -37,12 +37,16 @@ def write_header_comment(from_doc: TOMLDocument, to_doc: TOMLDocument) -> None:
             return
 
 
-def convert_tomlkit_buggy_types(in_value: Any, parent: Any) -> Item:
+def convert_tomlkit_buggy_types(in_value: Any, parent: Any, key: str) -> Item:
     """Fix buggy items while iterating through tomlkit items.
 
     Iterating through tomlkit items can often be buggy; this function
     fixes it
     """
+    if isinstance(in_value, bool):
+        # Bool items don't have trivia and are resolved to Python's `bool`
+        # https://github.com/sdispater/tomlkit/issues/119#issuecomment-955840942
+        return parent.value.item(key)
     if isinstance(in_value, Item):
         return in_value
     if isinstance(in_value, Container):
@@ -94,7 +98,7 @@ class TomlSort:
         is not necessary.
         """
         table_items = [
-            (key, convert_tomlkit_buggy_types(parent[key], parent))
+            (key, convert_tomlkit_buggy_types(parent[key], parent, key))
             for key in parent.keys()
         ]
         tables = (


### PR DESCRIPTION
Fixes `tomlkit` behaviour where `Bool` is missing trivia.
Behaviour won't be corrected in `tomlkit` itself: https://github.com/sdispater/tomlkit/issues/119#issuecomment-955840942