### PR TITLE
Add the ability to sort inline tables and inline arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,37 +33,48 @@ This project can be used as either a command line utility or a Python library. R
 
 ```console
 $ toml-sort --help
-usage: toml-sort [-h] [--version] [-o OUTPUT] [-a] [-i]
-                 [--no-comments] [--no-header-comments] [--no-footer-comments]
-                 [--no-inline-comments] [--no-block-comments]
-                 [--spaces-before-inline-comment {1,2,3,4}] [--check] [-I]
-                 [F ...]
+usage: toml-sort [-h] [--version] [-o OUTPUT] [-i] [-I] [-a] [--no-sort-tables] [--sort-table-keys]
+                 [--sort-inline-tables] [--sort-inline-arrays] [--no-header] [--no-comments] [--no-header-comments]
+                 [--no-footer-comments] [--no-inline-comments] [--no-block-comments]
+                 [--spaces-before-inline-comment {1,2,3,4}] [--check]
+                 [F [F ...]]
 
 Toml sort: a sorting utility for toml files.
 
 positional arguments:
   F                     filename(s) to be processed by toml-sort (default: -)
 
-options:
+optional arguments:
   -h, --help            show this help message and exit
   --version             display version information and exit
   -o OUTPUT, --output OUTPUT
                         output filepath (default: '-')
-  -a, --all             sort ALL keys (default: only sort non-inline 'tables
-                        and arrays of tables')
   -i, --in-place        overwrite the original input file with changes
-  --no-comments         remove all comments. Implies no header, footer,
-                        inline, or block comments
+  --check               silently check if an original file would be changed by the formatter
+
+sort:
+  change sorting behavior
+
+  -I, --ignore-case     ignore case when sorting
+  -a, --all             sort ALL keys. This implies sort table-keys, inline-tables and inline arrays. (default: only
+                        sort non-inline 'tables and arrays of tables')
+  --no-sort-tables      Disables the default behavior of sorting tables and arrays of tables by their header value.
+                        Setting this option will keep the order of tables in the toml file the same.
+  --sort-table-keys     Sort the keys in tables and arrays of tables (excluding inline tables and arrays).
+  --sort-inline-tables  Sort inline tables.
+  --sort-inline-arrays  Sort inline arrays.
+
+comments:
+  exclude comments from output
+
+  --no-header           Deprecated. See --no-header-comments
+  --no-comments         remove all comments. Implies no header, footer, inline, or block comments
   --no-header-comments  remove a document's leading comments
   --no-footer-comments  remove a document's trailing comments
   --no-inline-comments  remove a document's inline comments
   --no-block-comments   remove a document's block comments
   --spaces-before-inline-comment {1,2,3,4}
-                        the number of spaces before an inline comment
-                        (default: 1)
-  --check               silently check if an original file would be changed by
-                        the formatter
-  -I, --ignore-case     ignore case when sorting
+                        the number of spaces before an inline comment (default: 1)
 
 Examples:
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ $ toml-sort --help
 usage: toml-sort [-h] [--version] [-o OUTPUT] [-i] [-I] [-a] [--no-sort-tables] [--sort-table-keys]
                  [--sort-inline-tables] [--sort-inline-arrays] [--no-header] [--no-comments] [--no-header-comments]
                  [--no-footer-comments] [--no-inline-comments] [--no-block-comments]
-                 [--spaces-before-inline-comment {1,2,3,4}] [--check]
+                 [--spaces-before-inline-comment {1,2,3,4}] [--spaces-indent-inline-array {2,4,6,8}]
+                 [--trailing-comma-inline-array] [--check]
                  [F [F ...]]
 
 Toml sort: a sorting utility for toml files.
@@ -73,8 +74,16 @@ comments:
   --no-footer-comments  remove a document's trailing comments
   --no-inline-comments  remove a document's inline comments
   --no-block-comments   remove a document's block comments
+
+formatting:
+  options to change output formatting
+
   --spaces-before-inline-comment {1,2,3,4}
                         the number of spaces before an inline comment (default: 1)
+  --spaces-indent-inline-array {2,4,6,8}
+                        the number of spaces to indent a multiline inline array (default: 2)
+  --trailing-comma-inline-array
+                        add trailing comma to the last item in a multiline inline array
 
 Examples:
 
@@ -110,7 +119,13 @@ no_header_comments = true
 no_footer_comments = true
 no_inline_comments = true
 no_block_comments = true
+no_sort_tables = true
+sort_table_keys = true
+sort_inline_tables = true
+sort_inline_arrays = true
 spaces_before_inline_comment = 2
+spaces_indent_inline_array = 4
+trailing_comma_inline_array = true
 check = true
 ignore_case = true
 ```

--- a/tests/examples/inline.toml
+++ b/tests/examples/inline.toml
@@ -1,0 +1,45 @@
+[b]
+blist=[    'c',     'a', 'b'] # Comment
+alist = [
+  'g',
+
+
+
+# Comment attached
+    'w', # Comment inline
+
+     # Orphan comment
+
+  #Multiline
+#   Second attached comment
+  'a'
+
+]
+'aalist' = { c="test", a=       "another test"       }#list comment
+# Multilevel inline array
+aaalist = [
+  [
+    {  name="Homer Simpson", town  ="Springfield"}
+  ],
+[
+{  name="Bart Simpson", town  ="Springfield"}
+],
+# Weird block comment
+    [
+# Another weird block comment
+          {name="Lisa Simpson", town  ="Springfield", a-test = "Did this sort?"}#Should get sorted
+  ],
+]
+[a]
+test = [
+{x = [
+"foo",
+"bar"
+], a = [
+""
+]},
+{y = [
+"foo",
+"baz"
+]}
+]

--- a/tests/examples/sorted/comment-comments-preserved.toml
+++ b/tests/examples/sorted/comment-comments-preserved.toml
@@ -15,7 +15,7 @@ name = "Samuel Roeca"
 [[a-section.hello]]
 dob = 1979-05-27T07:32:00Z  # First class dates? Why not?
 # test comment
-ports = [ 8001, 8001, 8002 ]
+ports = [8001, 8001, 8002]
 
 # Another test comment
 # make sure multiline comments work
@@ -23,7 +23,7 @@ ports = [ 8001, 8001, 8002 ]
 # multi line comment
 # test comment
 dob = 1920-05-27T07:32:00Z  # Another date!
-ports = [ 80 ]
+ports = [80]
 
 # Another comment
 [b-section]  # Comment there?

--- a/tests/examples/sorted/comment-header-footer.toml
+++ b/tests/examples/sorted/comment-header-footer.toml
@@ -17,13 +17,13 @@ name = "Samuel Roeca"
 # start test
 [[a-section.hello]]
 # test comment
-ports = [ 8001, 8001, 8002 ]
+ports = [8001, 8001, 8002]
 dob = 1979-05-27T07:32:00Z # First class dates? Why not?
 
 # Another test comment
 # make sure multiline comments work
 [[a-section.hello]] # Comment here?
-ports = [ 80 ]
+ports = [80]
 # multi line comment
 # test comment
 dob = 1920-05-27T07:32:00Z # Another date!

--- a/tests/examples/sorted/comment-no-comments.toml
+++ b/tests/examples/sorted/comment-no-comments.toml
@@ -9,11 +9,11 @@ name = "Samuel Roeca"
 
 [[a-section.hello]]
 dob = 1979-05-27T07:32:00Z
-ports = [ 8001, 8001, 8002 ]
+ports = [8001, 8001, 8002]
 
 [[a-section.hello]]
 dob = 1920-05-27T07:32:00Z
-ports = [ 80 ]
+ports = [80]
 
 [b-section]
 date = "2018"

--- a/tests/examples/sorted/from-toml-lang.toml
+++ b/tests/examples/sorted/from-toml-lang.toml
@@ -3,7 +3,7 @@
 title = "TOML Example"
 
 [clients]
-data = [ ["gamma", "delta"], [1, 2] ] # just an update to make sure parsers support it
+data = [["gamma", "delta"], [1, 2]] # just an update to make sure parsers support it
 # Line breaks are OK when inside arrays
 hosts = [
   "alpha",
@@ -12,7 +12,7 @@ hosts = [
 
 [database]
 server = "192.168.1.1"
-ports = [ 8001, 8001, 8002 ]
+ports = [8001, 8001, 8002]
 connection_max = 5000
 enabled = true # Comment after a boolean
 

--- a/tests/examples/sorted/inline-default.toml
+++ b/tests/examples/sorted/inline-default.toml
@@ -1,0 +1,39 @@
+[a]
+test = [
+  {x = [
+    "foo",
+    "bar"
+  ], a = [
+    ""
+  ]},
+  {y = [
+    "foo",
+    "baz"
+  ]}
+]
+
+[b]
+blist = ['c', 'a', 'b'] # Comment
+alist = [
+  'g',
+  # Comment attached
+  'w', # Comment inline
+  # Multiline
+  # Second attached comment
+  'a'
+]
+'aalist' = {c = "test", a = "another test"} # list comment
+# Multilevel inline array
+aaalist = [
+  [
+    {name = "Homer Simpson", town = "Springfield"}
+  ],
+  [
+    {name = "Bart Simpson", town = "Springfield"}
+  ],
+  # Weird block comment
+  [
+    # Another weird block comment
+    {name = "Lisa Simpson", town = "Springfield", a-test = "Did this sort?"} # Should get sorted
+  ]
+]

--- a/tests/examples/sorted/inline-no-comments-no-table-sort.toml
+++ b/tests/examples/sorted/inline-no-comments-no-table-sort.toml
@@ -1,0 +1,33 @@
+[b]
+aaalist = [
+  [
+    {a-test = "Did this sort?", name = "Lisa Simpson", town = "Springfield"}
+  ],
+  [
+    {name = "Bart Simpson", town = "Springfield"}
+  ],
+  [
+    {name = "Homer Simpson", town = "Springfield"}
+  ]
+]
+'aalist' = {a = "another test", c = "test"}
+alist = [
+  'a',
+  'g',
+  'w'
+]
+blist = ['a', 'b', 'c']
+
+[a]
+test = [
+  {a = [
+    ""
+  ], x = [
+    "bar",
+    "foo"
+  ]},
+  {y = [
+    "baz",
+    "foo"
+  ]}
+]

--- a/tests/examples/sorted/inline-no-comments-no-table-sort.toml
+++ b/tests/examples/sorted/inline-no-comments-no-table-sort.toml
@@ -1,33 +1,33 @@
 [b]
 aaalist = [
   [
-    {a-test = "Did this sort?", name = "Lisa Simpson", town = "Springfield"}
+    {a-test = "Did this sort?", name = "Lisa Simpson", town = "Springfield"},
   ],
   [
-    {name = "Bart Simpson", town = "Springfield"}
+    {name = "Bart Simpson", town = "Springfield"},
   ],
   [
-    {name = "Homer Simpson", town = "Springfield"}
-  ]
+    {name = "Homer Simpson", town = "Springfield"},
+  ],
 ]
 'aalist' = {a = "another test", c = "test"}
 alist = [
   'a',
   'g',
-  'w'
+  'w',
 ]
 blist = ['a', 'b', 'c']
 
 [a]
 test = [
   {a = [
-    ""
+    "",
   ], x = [
     "bar",
-    "foo"
+    "foo",
   ]},
   {y = [
     "baz",
-    "foo"
-  ]}
+    "foo",
+  ]},
 ]

--- a/tests/examples/sorted/inline.toml
+++ b/tests/examples/sorted/inline.toml
@@ -1,0 +1,39 @@
+[a]
+test = [
+  {a = [
+    ""
+  ], x = [
+    "bar",
+    "foo"
+  ]},
+  {y = [
+    "baz",
+    "foo"
+  ]}
+]
+
+[b]
+# Multilevel inline array
+aaalist = [
+  # Weird block comment
+  [
+    # Another weird block comment
+    {a-test = "Did this sort?", name = "Lisa Simpson", town = "Springfield"}  # Should get sorted
+  ],
+  [
+    {name = "Bart Simpson", town = "Springfield"}
+  ],
+  [
+    {name = "Homer Simpson", town = "Springfield"}
+  ]
+]
+'aalist' = {a = "another test", c = "test"}  # list comment
+alist = [
+  # Multiline
+  # Second attached comment
+  'a',
+  'g',
+  # Comment attached
+  'w'  # Comment inline
+]
+blist = ['a', 'b', 'c']  # Comment

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -143,6 +143,7 @@ def test_cli_defaults(
                 "--sort-inline-array",
                 "--sort-inline-table",
                 "--no-comments",
+                "--trailing-comma-inline-array",
             ],
         ),
     ],

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -57,6 +57,7 @@ def capture(
         pytest.param("weird", "sorted/weird", marks=[pytest.mark.xfail]),
         ("pyproject-weird-order", "sorted/pyproject-weird-order"),
         ("comment", "sorted/comment-header-footer"),
+        ("inline", "sorted/inline-default"),
     ],
 )
 def test_cli_defaults(
@@ -111,6 +112,37 @@ def test_cli_defaults(
                 "--spaces-before-inline-comment",
                 "2",
                 "--all",
+            ],
+        ),
+        (
+            "inline",
+            ["sorted", "inline"],
+            [
+                "--all",
+                "--spaces-before-inline-comment",
+                "2",
+            ],
+        ),
+        (
+            "inline",
+            ["sorted", "inline"],
+            [
+                "--sort-table-keys",
+                "--sort-inline-array",
+                "--sort-inline-table",
+                "--spaces-before-inline-comment",
+                "2",
+            ],
+        ),
+        (
+            "inline",
+            ["sorted", "inline-no-comments-no-table-sort"],
+            [
+                "--no-sort-tables",
+                "--sort-table-keys",
+                "--sort-inline-array",
+                "--sort-inline-table",
+                "--no-comments",
             ],
         ),
     ],

--- a/tests/test_toml_sort.py
+++ b/tests/test_toml_sort.py
@@ -7,7 +7,7 @@ from typing import Any, Callable, Dict, List
 import pytest
 
 from toml_sort import TomlSort
-from toml_sort.tomlsort import CommentConfiguration
+from toml_sort.tomlsort import CommentConfiguration, SortConfiguration
 
 
 def test_sort_toml_is_str() -> None:
@@ -19,6 +19,15 @@ def test_sort_toml_is_str() -> None:
 @pytest.mark.parametrize(
     "unsorted_fixture,sorted_fixture,args",
     [
+        (
+            "inline",
+            "inline",
+            {
+                "sort_config": SortConfiguration(
+                    inline_arrays=True, inline_tables=True
+                ),
+            },
+        ),
         (
             "comment",
             "comment-comments-preserved",
@@ -44,7 +53,7 @@ def test_sort_toml_is_str() -> None:
             "comment",
             "comment-header-footer",
             {
-                "only_sort_tables": True,
+                "sort_config": SortConfiguration(table_keys=False),
                 "comment_config": CommentConfiguration(spaces_before_inline=1),
             },
         ),
@@ -52,7 +61,7 @@ def test_sort_toml_is_str() -> None:
             "from-toml-lang",
             "from-toml-lang",
             {
-                "only_sort_tables": True,
+                "sort_config": SortConfiguration(table_keys=False),
                 "comment_config": CommentConfiguration(spaces_before_inline=1),
             },
         ),
@@ -60,7 +69,7 @@ def test_sort_toml_is_str() -> None:
             "pyproject-weird-order",
             "pyproject-weird-order",
             {
-                "only_sort_tables": True,
+                "sort_config": SortConfiguration(table_keys=False),
                 "comment_config": CommentConfiguration(
                     block=False, spaces_before_inline=1
                 ),
@@ -70,7 +79,7 @@ def test_sort_toml_is_str() -> None:
             "weird",
             "weird",
             {
-                "only_sort_tables": True,
+                "sort_config": SortConfiguration(table_keys=False),
                 "comment_config": CommentConfiguration(
                     block=False, spaces_before_inline=1
                 ),

--- a/tests/test_toml_sort.py
+++ b/tests/test_toml_sort.py
@@ -7,7 +7,11 @@ from typing import Any, Callable, Dict, List
 import pytest
 
 from toml_sort import TomlSort
-from toml_sort.tomlsort import CommentConfiguration, SortConfiguration
+from toml_sort.tomlsort import (
+    CommentConfiguration,
+    FormattingConfiguration,
+    SortConfiguration,
+)
 
 
 def test_sort_toml_is_str() -> None:
@@ -54,7 +58,9 @@ def test_sort_toml_is_str() -> None:
             "comment-header-footer",
             {
                 "sort_config": SortConfiguration(table_keys=False),
-                "comment_config": CommentConfiguration(spaces_before_inline=1),
+                "format_config": FormattingConfiguration(
+                    spaces_before_inline_comment=1
+                ),
             },
         ),
         (
@@ -62,7 +68,9 @@ def test_sort_toml_is_str() -> None:
             "from-toml-lang",
             {
                 "sort_config": SortConfiguration(table_keys=False),
-                "comment_config": CommentConfiguration(spaces_before_inline=1),
+                "format_config": FormattingConfiguration(
+                    spaces_before_inline_comment=1
+                ),
             },
         ),
         (
@@ -70,8 +78,9 @@ def test_sort_toml_is_str() -> None:
             "pyproject-weird-order",
             {
                 "sort_config": SortConfiguration(table_keys=False),
-                "comment_config": CommentConfiguration(
-                    block=False, spaces_before_inline=1
+                "comment_config": CommentConfiguration(block=False),
+                "format_config": FormattingConfiguration(
+                    spaces_before_inline_comment=1
                 ),
             },
         ),
@@ -81,7 +90,10 @@ def test_sort_toml_is_str() -> None:
             {
                 "sort_config": SortConfiguration(table_keys=False),
                 "comment_config": CommentConfiguration(
-                    block=False, spaces_before_inline=1
+                    block=False,
+                ),
+                "format_config": FormattingConfiguration(
+                    spaces_before_inline_comment=1
                 ),
             },
             marks=[pytest.mark.xfail],


### PR DESCRIPTION
This PR makes a few related changes:
- Optionally add the ability to sort inline tables and arrays (new switches added for this functionality: `--sort-inline-tables` and `--sort-inline-arrays`, which are implied by the `--all` option
- Add new options groups to the cli, to group the related formatting, comment, and sorting args
- Add some additional formatting checks
  - Make sure inline arrays and tables are consistently formatted
  - normalize the formatting for `key = value` pairs, always one space on either side of equals sign
  - Add switch to add trailing comma to multi-line inline arrays `--trailing-comma-inline-array`