### PR TITLE
Fix TypeError thrown when using dotted keys

### DIFF
--- a/tests/examples/dotted-key.toml
+++ b/tests/examples/dotted-key.toml
@@ -1,0 +1,14 @@
+# Header comment
+
+# Attached to project
+[project]
+# This is my homepage
+urls.homepage = "https://example.com"
+# Documentation
+urls.documentation = "https://readthedocs.org"
+
+[other-project]
+# test2
+deeply.deeply.deeply.nested.key.test2 = "test2"
+# test1
+deeply.deeply.deeply.nested.key.test1 = "test1"

--- a/tests/examples/sorted/dotted-key.toml
+++ b/tests/examples/sorted/dotted-key.toml
@@ -1,0 +1,14 @@
+# Header comment
+
+[other-project]
+# test1
+deeply.deeply.deeply.nested.key.test1 = "test1"
+# test2
+deeply.deeply.deeply.nested.key.test2 = "test2"
+
+# Attached to project
+[project]
+# Documentation
+urls.documentation = "https://readthedocs.org"
+# This is my homepage
+urls.homepage = "https://example.com"

--- a/tests/test_toml_sort.py
+++ b/tests/test_toml_sort.py
@@ -24,6 +24,15 @@ def test_sort_toml_is_str() -> None:
     "unsorted_fixture,sorted_fixture,args",
     [
         (
+            "dotted-key",
+            "dotted-key",
+            {
+                "sort_config": SortConfiguration(
+                    inline_arrays=True, inline_tables=True
+                ),
+            },
+        ),
+        (
             "inline",
             "inline",
             {

--- a/toml_sort/tomlsort.py
+++ b/toml_sort/tomlsort.py
@@ -470,17 +470,13 @@ class TomlSort:
         """
         if parent_table.is_super_table():
             if len(parent_table) == 0:
-                previous_item = grandparent
-            else:
-                last_item = parent_table.value.last_item()
-                if isinstance(last_item, Table):
-                    previous_item = last_item
-                else:
-                    # This is the case when dealing with a dotted key
-                    previous_item = parent_table
-        else:
-            previous_item = parent_table
-        return previous_item
+                return grandparent
+
+            last_item = parent_table.value.last_item()
+            if isinstance(last_item, Table):
+                return last_item
+
+        return parent_table
 
     def body_to_tomlsortitems(
         self, parent: List[Tuple[Optional[Key], Item]]

--- a/toml_sort/tomlsort.py
+++ b/toml_sort/tomlsort.py
@@ -473,12 +473,11 @@ class TomlSort:
                 previous_item = grandparent
             else:
                 last_item = parent_table.value.last_item()
-                if last_item is None or not isinstance(last_item, Table):
-                    type_str = str(type(last_item))
-                    raise TypeError(
-                        f"Unexpected type {type_str}, cannot insert comment."
-                    )
-                previous_item = last_item
+                if isinstance(last_item, Table):
+                    previous_item = last_item
+                else:
+                    # This is the case when dealing with a dotted key
+                    previous_item = parent_table
         else:
             previous_item = parent_table
         return previous_item


### PR DESCRIPTION
Resolves https://github.com/pappasam/toml-sort/issues/44

Before this branch running `toml-sort` against this input:

```toml
[project]
urls.homepage = "https://example.com"
urls.documentation = "https://readthedocs.org"
```

would throw the following exception:
```shell
$ toml-sort tests/examples/dotted-key.toml
Traceback (most recent call last):
  File "toml-sort", line 6, in <module>
    sys.exit(cli())
  File "projects/toml-sort/toml_sort/cli.py", line 332, in cli
    sorted_toml = TomlSort(
  File "projects/toml-sort/toml_sort/tomlsort.py", line 636, in sorted
    sorted_toml = self.toml_doc_sorted(toml_doc)
  File "projects/toml-sort/toml_sort/tomlsort.py", line 622, in toml_doc_sorted
    item.key, self.toml_elements_sorted(item, sorted_document)
  File "projects/toml-sort/toml_sort/tomlsort.py", line 441, in toml_elements_sorted
    item.key, self.toml_elements_sorted(item, previous_item)
  File "projects/toml-sort/toml_sort/tomlsort.py", line 441, in toml_elements_sorted
    item.key, self.toml_elements_sorted(item, previous_item)
  File "projects/toml-sort/toml_sort/tomlsort.py", line 441, in toml_elements_sorted
    item.key, self.toml_elements_sorted(item, previous_item)
  [Previous line repeated 2 more times]
  File "projects/toml-sort/toml_sort/tomlsort.py", line 438, in toml_elements_sorted
    previous_item = self.table_previous_item(new_table, parent)
  File "projects/toml-sort/toml_sort/tomlsort.py", line 478, in table_previous_item
    raise TypeError(
TypeError: Unexpected type <class 'tomlkit.items.String'>, cannot insert comment.
```

After this PR it correctly sorts.