### PR TITLE
Use pydantic for configuration validation

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -13,6 +13,8 @@ persistent=yes
 # usually to register additional checkers.
 load-plugins=
 
+# Whitelist pydantic extension
+extension-pkg-allow-list=pydantic
 
 [MESSAGES CONTROL]
 # can opt to enable instead if you want

--- a/poetry.lock
+++ b/poetry.lock
@@ -754,6 +754,59 @@ files = [
 ]
 
 [[package]]
+name = "pydantic"
+version = "1.10.5"
+description = "Data validation and settings management using python type hints"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pydantic-1.10.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:5920824fe1e21cbb3e38cf0f3dd24857c8959801d1031ce1fac1d50857a03bfb"},
+    {file = "pydantic-1.10.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:3bb99cf9655b377db1a9e47fa4479e3330ea96f4123c6c8200e482704bf1eda2"},
+    {file = "pydantic-1.10.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2185a3b3d98ab4506a3f6707569802d2d92c3a7ba3a9a35683a7709ea6c2aaa2"},
+    {file = "pydantic-1.10.5-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f582cac9d11c227c652d3ce8ee223d94eb06f4228b52a8adaafa9fa62e73d5c9"},
+    {file = "pydantic-1.10.5-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:c9e5b778b6842f135902e2d82624008c6a79710207e28e86966cd136c621bfee"},
+    {file = "pydantic-1.10.5-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:72ef3783be8cbdef6bca034606a5de3862be6b72415dc5cb1fb8ddbac110049a"},
+    {file = "pydantic-1.10.5-cp310-cp310-win_amd64.whl", hash = "sha256:45edea10b75d3da43cfda12f3792833a3fa70b6eee4db1ed6aed528cef17c74e"},
+    {file = "pydantic-1.10.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:63200cd8af1af2c07964546b7bc8f217e8bda9d0a2ef0ee0c797b36353914984"},
+    {file = "pydantic-1.10.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:305d0376c516b0dfa1dbefeae8c21042b57b496892d721905a6ec6b79494a66d"},
+    {file = "pydantic-1.10.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1fd326aff5d6c36f05735c7c9b3d5b0e933b4ca52ad0b6e4b38038d82703d35b"},
+    {file = "pydantic-1.10.5-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6bb0452d7b8516178c969d305d9630a3c9b8cf16fcf4713261c9ebd465af0d73"},
+    {file = "pydantic-1.10.5-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:9a9d9155e2a9f38b2eb9374c88f02fd4d6851ae17b65ee786a87d032f87008f8"},
+    {file = "pydantic-1.10.5-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:f836444b4c5ece128b23ec36a446c9ab7f9b0f7981d0d27e13a7c366ee163f8a"},
+    {file = "pydantic-1.10.5-cp311-cp311-win_amd64.whl", hash = "sha256:8481dca324e1c7b715ce091a698b181054d22072e848b6fc7895cd86f79b4449"},
+    {file = "pydantic-1.10.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:87f831e81ea0589cd18257f84386bf30154c5f4bed373b7b75e5cb0b5d53ea87"},
+    {file = "pydantic-1.10.5-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7ce1612e98c6326f10888df951a26ec1a577d8df49ddcaea87773bfbe23ba5cc"},
+    {file = "pydantic-1.10.5-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:58e41dd1e977531ac6073b11baac8c013f3cd8706a01d3dc74e86955be8b2c0c"},
+    {file = "pydantic-1.10.5-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:6a4b0aab29061262065bbdede617ef99cc5914d1bf0ddc8bcd8e3d7928d85bd6"},
+    {file = "pydantic-1.10.5-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:36e44a4de37b8aecffa81c081dbfe42c4d2bf9f6dff34d03dce157ec65eb0f15"},
+    {file = "pydantic-1.10.5-cp37-cp37m-win_amd64.whl", hash = "sha256:261f357f0aecda005934e413dfd7aa4077004a174dafe414a8325e6098a8e419"},
+    {file = "pydantic-1.10.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b429f7c457aebb7fbe7cd69c418d1cd7c6fdc4d3c8697f45af78b8d5a7955760"},
+    {file = "pydantic-1.10.5-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:663d2dd78596c5fa3eb996bc3f34b8c2a592648ad10008f98d1348be7ae212fb"},
+    {file = "pydantic-1.10.5-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51782fd81f09edcf265823c3bf43ff36d00db246eca39ee765ef58dc8421a642"},
+    {file = "pydantic-1.10.5-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c428c0f64a86661fb4873495c4fac430ec7a7cef2b8c1c28f3d1a7277f9ea5ab"},
+    {file = "pydantic-1.10.5-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:76c930ad0746c70f0368c4596020b736ab65b473c1f9b3872310a835d852eb19"},
+    {file = "pydantic-1.10.5-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:3257bd714de9db2102b742570a56bf7978e90441193acac109b1f500290f5718"},
+    {file = "pydantic-1.10.5-cp38-cp38-win_amd64.whl", hash = "sha256:f5bee6c523d13944a1fdc6f0525bc86dbbd94372f17b83fa6331aabacc8fd08e"},
+    {file = "pydantic-1.10.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:532e97c35719f137ee5405bd3eeddc5c06eb91a032bc755a44e34a712420daf3"},
+    {file = "pydantic-1.10.5-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:ca9075ab3de9e48b75fa8ccb897c34ccc1519177ad8841d99f7fd74cf43be5bf"},
+    {file = "pydantic-1.10.5-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bd46a0e6296346c477e59a954da57beaf9c538da37b9df482e50f836e4a7d4bb"},
+    {file = "pydantic-1.10.5-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3353072625ea2a9a6c81ad01b91e5c07fa70deb06368c71307529abf70d23325"},
+    {file = "pydantic-1.10.5-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:3f9d9b2be177c3cb6027cd67fbf323586417868c06c3c85d0d101703136e6b31"},
+    {file = "pydantic-1.10.5-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:b473d00ccd5c2061fd896ac127b7755baad233f8d996ea288af14ae09f8e0d1e"},
+    {file = "pydantic-1.10.5-cp39-cp39-win_amd64.whl", hash = "sha256:5f3bc8f103b56a8c88021d481410874b1f13edf6e838da607dcb57ecff9b4594"},
+    {file = "pydantic-1.10.5-py3-none-any.whl", hash = "sha256:7c5b94d598c90f2f46b3a983ffb46ab806a67099d118ae0da7ef21a2a4033b28"},
+    {file = "pydantic-1.10.5.tar.gz", hash = "sha256:9e337ac83686645a46db0e825acceea8e02fca4062483f40e9ae178e8bd1103a"},
+]
+
+[package.dependencies]
+typing-extensions = ">=4.2.0"
+
+[package.extras]
+dotenv = ["python-dotenv (>=0.10.4)"]
+email = ["email-validator (>=1.0.3)"]
+
+[[package]]
 name = "pygments"
 version = "2.14.0"
 description = "Pygments is a syntax highlighting package written in Python."
@@ -1237,7 +1290,7 @@ files = [
 name = "typing-extensions"
 version = "4.4.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -1388,4 +1441,4 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "8dc9a7ebe322d5faf943a5e129a901d4c96cf9c0c203da76d4bcb46b97ac5f37"
+content-hash = "9b439c554adbf6e3fc1557a0973881b85928a8b1db49952f2335e71c84531f76"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ license = "MIT"
 [tool.poetry.dependencies]
 python = "^3.7"
 tomlkit = ">=0.11.2"
+pydantic = "^1.10.5"
 
 [tool.poetry.dev-dependencies]
 pylint = ">=2.13.9"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -280,9 +280,11 @@ def test_load_config_file(toml, expected):
 @pytest.mark.parametrize(
     "toml", ["[tool.tomlsort]\nunknown=2", "[tool.tomlsort]\nall=42"]
 )
-def test_load_config_file_invalid(toml):
+def test_load_config_file_invalid(toml, capsys):
     """Test error if pyproject.toml is not valid."""
     open_mock = mock.mock_open(read_data=toml)
     with mock.patch("toml_sort.cli.open", open_mock):
         with pytest.raises(SystemExit):
             cli.load_config_file()
+        captured = capsys.readouterr()
+        assert "validation error for tool.tomlsort" in captured.err

--- a/toml_sort/cli.py
+++ b/toml_sort/cli.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List, Optional
 import tomlkit
 from pydantic import ValidationError
 
-from .settings import TomlSortSettings
+from .settings import Settings
 from .tomlsort import (
     CommentConfiguration,
     FormattingConfiguration,
@@ -82,10 +82,10 @@ def load_config_file() -> Dict[str, Any]:
     config = dict(toml_sort_section)
 
     try:
-        validated_config = TomlSortSettings(**config)
+        validated_config = Settings(**config)
     except ValidationError as exception:
         error_message = str(exception).replace(
-            "TomlSortSettings", "tool.tomlsort"
+            Settings.__name__, "tool.tomlsort"
         )
         printerr(f"Unexpected configuration error: {error_message}")
         sys.exit(1)

--- a/toml_sort/settings.py
+++ b/toml_sort/settings.py
@@ -1,0 +1,31 @@
+"""TomlSort pyproject settings validation model."""
+from __future__ import annotations
+
+from pydantic import BaseModel, Extra, PositiveInt
+
+
+class TomlSortSettings(BaseModel):
+    """Used to validate settings loaded from pyproject.toml."""
+
+    all: None | bool
+    in_place: None | bool
+    no_header: None | bool
+    no_comments: None | bool
+    no_header_comments: None | bool
+    no_footer_comments: None | bool
+    no_inline_comments: None | bool
+    check: None | bool
+    ignore_case: None | bool
+    no_sort_tables: None | bool
+    sort_inline_tables: None | bool
+    sort_inline_arrays: None | bool
+    sort_table_keys: None | bool
+    spaces_before_inline_comment: None | PositiveInt
+    spaces_indent_inline_array: None | PositiveInt
+    trailing_comma_inline_array: None | bool
+
+    class Config:  # pylint: disable=too-few-public-methods
+        """Pydantic model configuration."""
+
+        extra = Extra.forbid
+        frozen = True

--- a/toml_sort/settings.py
+++ b/toml_sort/settings.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from pydantic import BaseModel, Extra, PositiveInt
 
 
-class TomlSortSettings(BaseModel):
+class Settings(BaseModel):
     """Used to validate settings loaded from pyproject.toml."""
 
     all: None | bool

--- a/toml_sort/settings.py
+++ b/toml_sort/settings.py
@@ -1,5 +1,5 @@
 """TomlSort pyproject settings validation model."""
-from __future__ import annotations
+from typing import Optional
 
 from pydantic import BaseModel, Extra, PositiveInt
 
@@ -7,22 +7,22 @@ from pydantic import BaseModel, Extra, PositiveInt
 class Settings(BaseModel):
     """Used to validate settings loaded from pyproject.toml."""
 
-    all: None | bool
-    in_place: None | bool
-    no_header: None | bool
-    no_comments: None | bool
-    no_header_comments: None | bool
-    no_footer_comments: None | bool
-    no_inline_comments: None | bool
-    check: None | bool
-    ignore_case: None | bool
-    no_sort_tables: None | bool
-    sort_inline_tables: None | bool
-    sort_inline_arrays: None | bool
-    sort_table_keys: None | bool
-    spaces_before_inline_comment: None | PositiveInt
-    spaces_indent_inline_array: None | PositiveInt
-    trailing_comma_inline_array: None | bool
+    all: Optional[bool]
+    in_place: Optional[bool]
+    no_header: Optional[bool]
+    no_comments: Optional[bool]
+    no_header_comments: Optional[bool]
+    no_footer_comments: Optional[bool]
+    no_inline_comments: Optional[bool]
+    check: Optional[bool]
+    ignore_case: Optional[bool]
+    no_sort_tables: Optional[bool]
+    sort_inline_tables: Optional[bool]
+    sort_inline_arrays: Optional[bool]
+    sort_table_keys: Optional[bool]
+    spaces_before_inline_comment: Optional[PositiveInt]
+    spaces_indent_inline_array: Optional[PositiveInt]
+    trailing_comma_inline_array: Optional[bool]
 
     class Config:  # pylint: disable=too-few-public-methods
         """Pydantic model configuration."""


### PR DESCRIPTION
I was thinking about implementing some additional configuration options, so that you could override configuration on a table by table basis as I mentioned in this comment https://github.com/pappasam/toml-sort/issues/43#issuecomment-1434515344

In order to do this, we would need to do a bit more complicated configuration validation to validate each override section. As a first step in this direction I changed the configuration validation to use [pydantic](https://docs.pydantic.dev/), without adding any additional configuration changes.

I think pydantic provides nicer error messages when there is an issue with the configuration. Here is what it looks like when `no_header_comments` and `no_footer_comments` are set to a number instead of a `bool`:
```
Unexpected configuration error: 2 validation errors for tool.tomlsort
no_header_comments
  value could not be parsed to a boolean (type=type_error.bool)
no_footer_comments
  value could not be parsed to a boolean (type=type_error.bool)
```