### PR TITLE
Enable running tests on a mac

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,6 @@ envlist = py37,py38,py39,py310,py311
 isolated_build = true
 skipsdist = true
 [testenv]
-platform = linux
 whitelist_externals = poetry
 skip_install = true
 commands =


### PR DESCRIPTION
I'm developing on a mac, and when I try to run the tests I get this message: 

```
________________________________________________ summary _________________________________________________
SKIPPED:  py: platform mismatch ('darwin' does not match 'linux')
  congratulations :)
```

Removing the platform line in the tox configuration allows the tests to run locally for me. 