### PR TITLE
Override sort configuration per key in configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,45 @@ check = true
 ignore_case = true
 ```
 
+### Configuration overrides
+The `pyproject.toml` configuration also supports configuration overrides, which are not available as command line arguments. These overrides allow fine grained control of sort options for particular keys.
+
+Only the options below can be included in an override:
+
+```toml
+[tool.tomlsort.overrides."path.to.key"]
+table_keys = true
+inline_tables = true
+inline_arrays = true
+```
+
+Where `path.to.key` in the example configuration is the key to match. Keys are matched using the [Python fnmatch function](https://docs.python.org/3/library/fnmatch.html), so glob style wildcards are supported. 
+
+For example to disable the sorting the inline array in the following toml file.
+
+```toml
+[servers.beta]
+ip = "10.0.0.2"
+dc = "eqdc10"
+country = "中国"
+```
+
+Any of the following overrides could be used
+```toml
+# Overrides in own table
+[tool.tomlsort.overrides."servers.beta"]
+table_keys = false
+
+# Overrides in the tomlsort table
+[tool.tomlsort]
+overrides."servers.beta".table_keys = false
+
+# Override using a wildcard if config should be 
+# applied to all servers keys
+[tool.tomlsort]
+overrides."servers.*".table_keys = false
+```
+
 ## Comments
 
 Due to the free form nature of comments, it is hard to include them in a sort in a generic way that will work for everyone. `toml-sort` deals with four different types of comments. They are all enabled by default, but can be disabled using CLI switches, in which case comments of that type will be removed from the output.

--- a/README.md
+++ b/README.md
@@ -130,10 +130,10 @@ check = true
 ignore_case = true
 ```
 
-### Configuration overrides
-The `pyproject.toml` configuration also supports configuration overrides, which are not available as command line arguments. These overrides allow fine grained control of sort options for particular keys.
+### Configuration Overrides
+The `pyproject.toml` configuration file also supports configuration overrides, which are not available as command-line arguments. These overrides allow for fine-grained control of sort options for particular keys.
 
-Only the options below can be included in an override:
+Only the following options can be included in an override:
 
 ```toml
 [tool.tomlsort.overrides."path.to.key"]
@@ -142,9 +142,9 @@ inline_tables = true
 inline_arrays = true
 ```
 
-Where `path.to.key` in the example configuration is the key to match. Keys are matched using the [Python fnmatch function](https://docs.python.org/3/library/fnmatch.html), so glob style wildcards are supported. 
+In the example configuration, `path.to.key` is the key to match. Keys are matched using the [Python fnmatch function](https://docs.python.org/3/library/fnmatch.html), so glob-style wildcards are supported. 
 
-For example to disable the sorting the inline array in the following toml file.
+For instance, to disable sorting the table in the following TOML file:
 
 ```toml
 [servers.beta]
@@ -153,7 +153,8 @@ dc = "eqdc10"
 country = "中国"
 ```
 
-Any of the following overrides could be used
+You can use any of the following overrides:
+
 ```toml
 # Overrides in own table
 [tool.tomlsort.overrides."servers.beta"]
@@ -163,8 +164,7 @@ table_keys = false
 [tool.tomlsort]
 overrides."servers.beta".table_keys = false
 
-# Override using a wildcard if config should be 
-# applied to all servers keys
+# Override using a wildcard if config should be applied to all servers keys
 [tool.tomlsort]
 overrides."servers.*".table_keys = false
 ```

--- a/tests/examples/sorted/from-toml-lang-overrides.toml
+++ b/tests/examples/sorted/from-toml-lang-overrides.toml
@@ -1,0 +1,44 @@
+# This is a TOML document. Boom.
+
+title = "TOML Example"
+
+[clients]
+data = [["gamma", "delta"], [1, 2]] # just an update to make sure parsers support it
+# Line breaks are OK when inside arrays
+hosts = [
+  "alpha",
+  "omega"
+]
+
+[database]
+connection_max = 5000
+enabled = true # Comment after a boolean
+ports = [8001, 8001, 8002]
+server = "192.168.1.1"
+
+[owner]
+bio = "GitHub Cofounder & CEO\nLikes tater tots and beer."
+dob = 1979-05-27T07:32:00Z # First class dates? Why not?
+name = "Tom Preston-Werner"
+organization = "GitHub"
+
+[[products]]
+name = "Hammer"
+sku = 738594937
+
+[[products]]
+color = "gray"
+name = "Nail"
+sku = 284758393
+
+[servers]
+
+# You can indent as you please. Tabs or spaces. TOML don't care.
+[servers.alpha]
+dc = "eqdc10"
+ip = "10.0.0.1"
+
+[servers.beta]
+ip = "10.0.0.2"
+dc = "eqdc10"
+country = "中国" # This should be parsed as UTF-8

--- a/tests/test_toml_sort.py
+++ b/tests/test_toml_sort.py
@@ -11,6 +11,7 @@ from toml_sort.tomlsort import (
     CommentConfiguration,
     FormattingConfiguration,
     SortConfiguration,
+    SortOverrideConfiguration,
 )
 
 
@@ -80,6 +81,26 @@ def test_sort_toml_is_str() -> None:
                 "format_config": FormattingConfiguration(
                     spaces_before_inline_comment=1
                 ),
+            },
+        ),
+        (
+            "from-toml-lang",
+            "from-toml-lang-overrides",
+            {
+                "sort_config": SortConfiguration(
+                    inline_arrays=True, inline_tables=True
+                ),
+                "format_config": FormattingConfiguration(
+                    spaces_before_inline_comment=1
+                ),
+                "sort_config_overrides": {
+                    "servers.beta": SortOverrideConfiguration(
+                        table_keys=False
+                    ),
+                    "clients.data": SortOverrideConfiguration(
+                        inline_arrays=False
+                    ),
+                },
             },
         ),
         (

--- a/toml_sort/tomlsort.py
+++ b/toml_sort/tomlsort.py
@@ -126,9 +126,8 @@ def coalesce_tables(
 class TomlSortKeys:
     """Keeps track of the Keys for a particular TomlSortItem.
 
-    We use this to keep track of the full path of an item
-    so that we can find the configuration overrides that
-    apply to it.
+    We use this to keep track of the full path of an item so that we can
+    find the configuration overrides that apply to it.
     """
 
     keys: List[Key]


### PR DESCRIPTION
This PR should resolve https://github.com/pappasam/toml-sort/issues/43 by adding the ability to override the sort configuration per key in the `pyproject.toml` file. This ability was not added to the command line switches, as I wasn't sure what a good way to represent this detailed configuration on the command line would be. 

Configuration overrides are matched using the [fnmatch](https://docs.python.org/3/library/fnmatch.html) function so there is support for glob style wildcards when matching keys. 

In order to support this functionality a data new class was added `TomlSortKeys` that keeps track of the full set of keys to a particular `TomlSortItem`, so that we can find the matching configuration overrides.