### PR TITLE
Add option to sort particular keys first in output

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,45 @@ check = true
 ignore_case = true
 ```
 
+### Configuration overrides
+The `pyproject.toml` configuration also supports configuration overrides, which are not available as command line arguments. These overrides allow fine grained control of sort options for particular keys.
+
+Only the options below can be included in an override:
+
+```toml
+[tool.tomlsort.overrides."path.to.key"]
+table_keys = true
+inline_tables = true
+inline_arrays = true
+```
+
+Where `path.to.key` in the example configuration is the key to match. Keys are matched using the [Python fnmatch function](https://docs.python.org/3/library/fnmatch.html), so glob style wildcards are supported. 
+
+For example to disable the sorting the inline array in the following toml file.
+
+```toml
+[servers.beta]
+ip = "10.0.0.2"
+dc = "eqdc10"
+country = "中国"
+```
+
+Any of the following overrides could be used
+```toml
+# Overrides in own table
+[tool.tomlsort.overrides."servers.beta"]
+table_keys = false
+
+# Overrides in the tomlsort table
+[tool.tomlsort]
+overrides."servers.beta".table_keys = false
+
+# Override using a wildcard if config should be 
+# applied to all servers keys
+[tool.tomlsort]
+overrides."servers.*".table_keys = false
+```
+
 ## Comments
 
 Due to the free form nature of comments, it is hard to include them in a sort in a generic way that will work for everyone. `toml-sort` deals with four different types of comments. They are all enabled by default, but can be disabled using CLI switches, in which case comments of that type will be removed from the output.

--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ This project can be used as either a command line utility or a Python library. R
 ```console
 $ toml-sort --help
 usage: toml-sort [-h] [--version] [-o OUTPUT] [-i] [-I] [-a] [--no-sort-tables] [--sort-table-keys]
-                 [--sort-inline-tables] [--sort-inline-arrays] [--no-header] [--no-comments] [--no-header-comments]
-                 [--no-footer-comments] [--no-inline-comments] [--no-block-comments]
+                 [--sort-inline-tables] [--sort-inline-arrays] [--sort-first KEYS] [--no-header] [--no-comments]
+                 [--no-header-comments] [--no-footer-comments] [--no-inline-comments] [--no-block-comments]
                  [--spaces-before-inline-comment {1,2,3,4}] [--spaces-indent-inline-array {2,4,6,8}]
                  [--trailing-comma-inline-array] [--check]
-                 [F [F ...]]
+                 [F ...]
 
 Toml sort: a sorting utility for toml files.
 
@@ -64,6 +64,8 @@ sort:
   --sort-table-keys     Sort the keys in tables and arrays of tables (excluding inline tables and arrays).
   --sort-inline-tables  Sort inline tables.
   --sort-inline-arrays  Sort inline arrays.
+  --sort-first KEYS     Table keys that will be sorted first in the output. Multiple keys can be given separated by a
+                        comma.
 
 comments:
   exclude comments from output
@@ -120,6 +122,7 @@ no_footer_comments = true
 no_inline_comments = true
 no_block_comments = true
 no_sort_tables = true
+sort_first = ["key1", "key2"]
 sort_table_keys = true
 sort_inline_tables = true
 sort_inline_arrays = true
@@ -137,6 +140,7 @@ Only the following options can be included in an override:
 
 ```toml
 [tool.tomlsort.overrides."path.to.key"]
+first = ["key1", "key2"]
 table_keys = true
 inline_tables = true
 inline_arrays = true

--- a/README.md
+++ b/README.md
@@ -130,10 +130,10 @@ check = true
 ignore_case = true
 ```
 
-### Configuration overrides
-The `pyproject.toml` configuration also supports configuration overrides, which are not available as command line arguments. These overrides allow fine grained control of sort options for particular keys.
+### Configuration Overrides
+The `pyproject.toml` configuration file also supports configuration overrides, which are not available as command-line arguments. These overrides allow for fine-grained control of sort options for particular keys.
 
-Only the options below can be included in an override:
+Only the following options can be included in an override:
 
 ```toml
 [tool.tomlsort.overrides."path.to.key"]
@@ -142,9 +142,9 @@ inline_tables = true
 inline_arrays = true
 ```
 
-Where `path.to.key` in the example configuration is the key to match. Keys are matched using the [Python fnmatch function](https://docs.python.org/3/library/fnmatch.html), so glob style wildcards are supported. 
+In the example configuration, `path.to.key` is the key to match. Keys are matched using the [Python fnmatch function](https://docs.python.org/3/library/fnmatch.html), so glob-style wildcards are supported. 
 
-For example to disable the sorting the inline array in the following toml file.
+For instance, to disable sorting the table in the following TOML file:
 
 ```toml
 [servers.beta]
@@ -153,7 +153,8 @@ dc = "eqdc10"
 country = "中国"
 ```
 
-Any of the following overrides could be used
+You can use any of the following overrides:
+
 ```toml
 # Overrides in own table
 [tool.tomlsort.overrides."servers.beta"]
@@ -163,8 +164,7 @@ table_keys = false
 [tool.tomlsort]
 overrides."servers.beta".table_keys = false
 
-# Override using a wildcard if config should be 
-# applied to all servers keys
+# Override using a wildcard if config should be applied to all servers keys
 [tool.tomlsort]
 overrides."servers.*".table_keys = false
 ```

--- a/tests/examples/sorted/from-toml-lang-first.toml
+++ b/tests/examples/sorted/from-toml-lang-first.toml
@@ -1,0 +1,44 @@
+# This is a TOML document. Boom.
+
+title = "TOML Example"
+
+[servers]
+
+# You can indent as you please. Tabs or spaces. TOML don't care.
+[servers.alpha]
+dc = "eqdc10"
+ip = "10.0.0.1"
+
+[servers.beta]
+country = "中国" # This should be parsed as UTF-8
+dc = "eqdc10"
+ip = "10.0.0.2"
+
+[[products]]
+name = "Hammer"
+sku = 738594937
+
+[[products]]
+color = "gray"
+name = "Nail"
+sku = 284758393
+
+[clients]
+data = [["delta", "gamma"], [1, 2]] # just an update to make sure parsers support it
+# Line breaks are OK when inside arrays
+hosts = [
+  "alpha",
+  "omega"
+]
+
+[database]
+ports = [8001, 8001, 8002]
+connection_max = 5000
+enabled = true # Comment after a boolean
+server = "192.168.1.1"
+
+[owner]
+name = "Tom Preston-Werner"
+dob = 1979-05-27T07:32:00Z # First class dates? Why not?
+bio = "GitHub Cofounder & CEO\nLikes tater tots and beer."
+organization = "GitHub"

--- a/tests/examples/sorted/from-toml-lang-overrides.toml
+++ b/tests/examples/sorted/from-toml-lang-overrides.toml
@@ -1,0 +1,44 @@
+# This is a TOML document. Boom.
+
+title = "TOML Example"
+
+[clients]
+data = [["gamma", "delta"], [1, 2]] # just an update to make sure parsers support it
+# Line breaks are OK when inside arrays
+hosts = [
+  "alpha",
+  "omega"
+]
+
+[database]
+connection_max = 5000
+enabled = true # Comment after a boolean
+ports = [8001, 8001, 8002]
+server = "192.168.1.1"
+
+[owner]
+bio = "GitHub Cofounder & CEO\nLikes tater tots and beer."
+dob = 1979-05-27T07:32:00Z # First class dates? Why not?
+name = "Tom Preston-Werner"
+organization = "GitHub"
+
+[[products]]
+name = "Hammer"
+sku = 738594937
+
+[[products]]
+color = "gray"
+name = "Nail"
+sku = 284758393
+
+[servers]
+
+# You can indent as you please. Tabs or spaces. TOML don't care.
+[servers.alpha]
+dc = "eqdc10"
+ip = "10.0.0.1"
+
+[servers.beta]
+ip = "10.0.0.2"
+dc = "eqdc10"
+country = "中国" # This should be parsed as UTF-8

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -279,6 +279,7 @@ def test_load_config_file_read():
             "[tool.tomlsort]\nspaces_before_inline_comment=4",
             {"spaces_before_inline_comment": 4},
         ),
+        ("[tool.tomlsort]\nsort_first=['x', 'y']", {"sort_first": "x,y"}),
     ],
 )
 def test_load_config_file(toml, expected):
@@ -337,6 +338,17 @@ def test_load_config_file_invalid(toml):
                 "test.123": SortOverrideConfiguration(table_keys=False),
                 "test.456": SortOverrideConfiguration(inline_tables=False),
                 "test.789": SortOverrideConfiguration(inline_arrays=False),
+            },
+        ),
+        (
+            """
+                    [tool.tomlsort.overrides]
+                    "test.123".first = ["one", "two", "three"]
+                    """,
+            {
+                "test.123": SortOverrideConfiguration(
+                    first=["one", "two", "three"]
+                ),
             },
         ),
     ],

--- a/tests/test_toml_sort.py
+++ b/tests/test_toml_sort.py
@@ -104,6 +104,24 @@ def test_sort_toml_is_str() -> None:
             },
         ),
         (
+            "from-toml-lang",
+            "from-toml-lang-first",
+            {
+                "sort_config": SortConfiguration(
+                    inline_arrays=True,
+                    inline_tables=True,
+                    first=["servers", "products"],
+                ),
+                "format_config": FormattingConfiguration(
+                    spaces_before_inline_comment=1
+                ),
+                "sort_config_overrides": {
+                    "database": SortOverrideConfiguration(first=["ports"]),
+                    "owner": SortOverrideConfiguration(first=["name", "dob"]),
+                },
+            },
+        ),
+        (
             "pyproject-weird-order",
             "pyproject-weird-order",
             {

--- a/tests/test_toml_sort.py
+++ b/tests/test_toml_sort.py
@@ -11,6 +11,7 @@ from toml_sort.tomlsort import (
     CommentConfiguration,
     FormattingConfiguration,
     SortConfiguration,
+    SortOverrideConfiguration,
 )
 
 
@@ -80,6 +81,26 @@ def test_sort_toml_is_str() -> None:
                 "format_config": FormattingConfiguration(
                     spaces_before_inline_comment=1
                 ),
+            },
+        ),
+        (
+            "from-toml-lang",
+            "from-toml-lang-overrides",
+            {
+                "sort_config": SortConfiguration(
+                    inline_arrays=True, inline_tables=True
+                ),
+                "format_config": FormattingConfiguration(
+                    spaces_before_inline_comment=1
+                ),
+                "sort_config_overrides": {
+                    "servers.beta": SortOverrideConfiguration(
+                        table_keys=False
+                    ),
+                    "clients.data": SortOverrideConfiguration(
+                        inline_arrays=False
+                    ),
+                },
             },
         ),
         (

--- a/toml_sort/cli.py
+++ b/toml_sort/cli.py
@@ -124,6 +124,9 @@ def parse_config(tomlsort_section: TOMLDocument) -> Dict[str, Any]:
     validate_and_copy(
         config, clean_config, "trailing_comma_inline_array", bool
     )
+    validate_and_copy(config, clean_config, "sort_first", list)
+    if "sort_first" in clean_config:
+        clean_config["sort_first"] = ",".join(clean_config["sort_first"])
 
     if config:
         printerr(f"Unexpected configuration values: {config}")
@@ -241,6 +244,16 @@ Notes:
         "--sort-inline-arrays",
         help=("Sort inline arrays."),
         action="store_true",
+    )
+    sort.add_argument(
+        "--sort-first",
+        help=(
+            "Table keys that will be sorted first in the output. Multiple "
+            "keys can be given separated by a comma."
+        ),
+        metavar="KEYS",
+        type=str,
+        default="",
     )
     comments = parser.add_argument_group(
         "comments", "exclude comments from output"
@@ -386,6 +399,7 @@ def cli(  # pylint: disable=too-many-branches
                 table_keys=bool(args.sort_table_keys or args.all),
                 inline_tables=bool(args.sort_inline_tables or args.all),
                 inline_arrays=bool(args.sort_inline_arrays or args.all),
+                first=args.sort_first.split(","),
             ),
             format_config=FormattingConfiguration(
                 spaces_before_inline_comment=args.spaces_before_inline_comment,

--- a/toml_sort/tomlsort.py
+++ b/toml_sort/tomlsort.py
@@ -126,9 +126,8 @@ def coalesce_tables(
 class TomlSortKeys:
     """Keeps track of the Keys for a particular TomlSortItem.
 
-    We use this to keep track of the full path of an item
-    so that we can find the configuration overrides that
-    apply to it.
+    We use this to keep track of the full path of an item so that we can
+    find the configuration overrides that apply to it.
     """
 
     keys: List[Key]


### PR DESCRIPTION
This PR builds on https://github.com/pappasam/toml-sort/pull/52, so that one should go in first.

This should resolve #42 by allowing a new configuration option `sort_first`, and adds this option to the new overrides configuration defined in #52.

For the case mentioned in #42, a configuration like this can be used:
```toml
[tool.tomlsort]
overrides."tool.poetry.dependencies".first = ["python"]
```