### PR TITLE
Update the behavior of --sort-first flag

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,6 +11,7 @@ from unittest import mock
 import pytest
 
 from toml_sort import cli
+from toml_sort.cli import parse_sort_first
 from toml_sort.tomlsort import SortOverrideConfiguration
 
 PATH_EXAMPLES = "tests/examples"
@@ -386,3 +387,25 @@ def test_load_config_overrides_fail(toml):
         with pytest.raises(SystemExit):
             section = cli.load_pyproject()
             cli.parse_config_overrides(section)
+
+
+@pytest.mark.parametrize(
+    "arg,expected_first,expected_overrides",
+    [
+        (
+            "a.b.c.d",
+            [],
+            {"a.b.c": SortOverrideConfiguration(first=["d"])},
+        ),
+        (
+            "a.b.c.d, a",
+            ["a"],
+            {"a.b.c": SortOverrideConfiguration(first=["d"])},
+        ),
+    ],
+)
+def test_parse_sort_first(arg, expected_first, expected_overrides):
+    """Test that we correctly parse the arg given for sort-first."""
+    first, overrides = parse_sort_first(arg, {})
+    assert first == expected_first
+    assert overrides == expected_overrides

--- a/toml_sort/cli.py
+++ b/toml_sort/cli.py
@@ -176,11 +176,7 @@ def parse_sort_first(
         else:
             path, base_key = split
             if path in overrides:
-                override = overrides[path]
-                if override.first is None:
-                    overrides[path].first = [base_key]
-                else:
-                    override.first.append(base_key)
+                overrides[path].first.append(base_key)
             else:
                 sort_override = SortOverrideConfiguration(first=[base_key])
                 overrides[path] = sort_override

--- a/toml_sort/cli.py
+++ b/toml_sort/cli.py
@@ -4,7 +4,7 @@ import argparse
 import dataclasses
 import sys
 from argparse import ArgumentParser
-from typing import Any, Dict, List, Optional, Type
+from typing import Any, Dict, List, Optional, Tuple, Type
 
 import tomlkit
 from tomlkit import TOMLDocument
@@ -156,6 +156,36 @@ def parse_config_overrides(
         overrides[path] = SortOverrideConfiguration(**settings)
 
     return overrides
+
+
+def parse_sort_first(
+    sort_first_arg: str, overrides: Dict[str, SortOverrideConfiguration]
+) -> Tuple[List[str], Dict[str, SortOverrideConfiguration]]:
+    """Parse the sort_first arg given on the command line.
+
+    If a dotted key is given on the command line for the sort-first
+    argument this function parses it, and adds it to the appropriate
+    override.
+    """
+    sort_first = []
+    for full_key in sort_first_arg.split(","):
+        full_key = full_key.strip()
+        split = full_key.rsplit(".", 1)
+        if len(split) == 1:
+            sort_first.append(full_key)
+        else:
+            path, base_key = split
+            if path in overrides:
+                override = overrides[path]
+                if override.first is None:
+                    overrides[path].first = [base_key]
+                else:
+                    override.first.append(base_key)
+            else:
+                sort_override = SortOverrideConfiguration(first=[base_key])
+                overrides[path] = sort_override
+
+    return sort_first, overrides
 
 
 def get_parser(defaults: Dict[str, Any]) -> ArgumentParser:
@@ -337,7 +367,7 @@ Notes:
     return parser
 
 
-def cli(  # pylint: disable=too-many-branches
+def cli(  # pylint: disable=too-many-branches,too-many-locals
     arguments: Optional[List[str]] = None,
 ) -> None:
     """Toml sort cli implementation."""
@@ -350,6 +380,9 @@ def cli(  # pylint: disable=too-many-branches
     if args.version:
         print(get_version())
         sys.exit(0)
+    sort_first, configuration_overrides = parse_sort_first(
+        args.sort_first, configuration_overrides
+    )
 
     filenames_clean = args.filenames if args.filenames else (STD_STREAM,)
     usage_errors = []
@@ -399,7 +432,7 @@ def cli(  # pylint: disable=too-many-branches
                 table_keys=bool(args.sort_table_keys or args.all),
                 inline_tables=bool(args.sort_inline_tables or args.all),
                 inline_arrays=bool(args.sort_inline_arrays or args.all),
-                first=args.sort_first.split(","),
+                first=sort_first,
             ),
             format_config=FormattingConfiguration(
                 spaces_before_inline_comment=args.spaces_before_inline_comment,

--- a/toml_sort/tomlsort.py
+++ b/toml_sort/tomlsort.py
@@ -164,6 +164,10 @@ class TomlSortKeys:
             keys = other.keys
         return TomlSortKeys(self.keys + keys)
 
+    def __repr__(self) -> str:
+        """Representation of TomlSortKeys."""
+        return f"<{self.__class__.__name__}: {self.as_string()}>"
+
 
 @dataclass
 class TomlSortItem:

--- a/toml_sort/tomlsort.py
+++ b/toml_sort/tomlsort.py
@@ -257,7 +257,7 @@ class SortOverrideConfiguration:
     table_keys: Optional[bool] = None
     inline_tables: Optional[bool] = None
     inline_arrays: Optional[bool] = None
-    first: Optional[List[str]] = None
+    first: List[str] = field(default_factory=list)
 
 
 class TomlSort:


### PR DESCRIPTION
Your comment here: https://github.com/pappasam/toml-sort/pull/53#issuecomment-1471149421

Made me think more about the behavior of the `--sort-first` flag, and the way it was implemented before did not make much sense from the cli point of view. 

This change allows the user to specify a dotted key for the `--sort-first` argument, that gets parsed before sorting, so that you can call the cli like this: 

```
toml-sort --all --sort-first tool.poetry.dev-dependencies.tox pyproject.toml
```