### PR TITLE
Fix TypeError when using Pyproject.toml

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -360,7 +360,21 @@ def test_load_config_overrides(toml, expected):
     open_mock = mock.mock_open(read_data=toml)
     with mock.patch("toml_sort.cli.open", open_mock):
         section = cli.load_pyproject()
-        assert expected == cli.parse_config_overrides(section)
+        assert isinstance(section, dict)
+        parsed = cli.parse_config_overrides(section)
+        assert expected == parsed
+        # Make sure we are returning normal python types rather
+        # than TOMLKit types.
+        for key, value in parsed.items():
+            assert type(key) == str  # pylint: disable=unidiomatic-typecheck
+            assert (
+                type(value)  # pylint: disable=unidiomatic-typecheck
+                == SortOverrideConfiguration
+            )
+            assert (
+                type(value.first)  # pylint: disable=unidiomatic-typecheck
+                == list
+            )
 
 
 @pytest.mark.parametrize(

--- a/toml_sort/cli.py
+++ b/toml_sort/cli.py
@@ -141,9 +141,10 @@ def parse_config_overrides(
     """Parse the tool.tomlsort.overrides section of the config."""
     fields = dataclasses.fields(SortOverrideConfiguration)
     settings_definition = {field.name: field.type for field in fields}
-    override_settings = dict(
-        tomlsort_section.get("overrides", tomlkit.document())
-    )
+    override_settings = tomlsort_section.get(
+        "overrides", tomlkit.document()
+    ).unwrap()
+
     overrides = {}
     for path, settings in override_settings.items():
         if not settings.keys() <= settings_definition.keys():


### PR DESCRIPTION
Found this error when using the `first` override in a pyproject.toml file. It was happening because tomlkit wrappers were making it into the configuration, causing the dataclass not to be serialize to a dict.

```
Traceback (most recent call last):
  File "/bin/toml-sort", line 8, in <module>
    sys.exit(cli())
  File "/toml_sort/cli.py", line 413, in cli
    sorted_toml = TomlSort(
  File "/toml_sort/tomlsort.py", line 810, in sorted
    sorted_toml = self.toml_doc_sorted(toml_doc)
  File "/toml_sort/tomlsort.py", line 796, in toml_doc_sorted
    self.toml_elements_sorted(item, sorted_document),
  File "/toml_sort/tomlsort.py", line 611, in toml_elements_sorted
    self.toml_elements_sorted(item, previous_item),
  File "/toml_sort/tomlsort.py", line 611, in toml_elements_sorted
    self.toml_elements_sorted(item, previous_item),
  File "/toml_sort/tomlsort.py", line 604, in toml_elements_sorted
    for item in self.sorted_children_table(
  File "/toml_sort/tomlsort.py", line 542, in sorted_children_table
    sort_config = self.sort_config(parent_keys)
  File "/toml_sort/tomlsort.py", line 336, in sort_config
    override_config = asdict(override)
  File "dataclasses.py", line 1075, in asdict
    return _asdict_inner(obj, dict_factory)
  File "dataclasses.py", line 1082, in _asdict_inner
    value = _asdict_inner(getattr(obj, f.name), dict_factory)
  File "dataclasses.py", line 1110, in _asdict_inner
    return type(obj)(_asdict_inner(v, dict_factory) for v in obj)
TypeError: __init__() missing 1 required positional argument: 'trivia'
```

Added a test to check that the types we get out of the config are plain old python objects and fixed this issue.