### PR TITLE
add inner spacing to inline objects (non-empty) - BREAKING

### DIFF
--- a/tests/examples/sorted/inline-default.toml
+++ b/tests/examples/sorted/inline-default.toml
@@ -1,15 +1,15 @@
 [a]
 test = [
-  {x = [
-    "foo",
-    "bar"
-  ], a = [
-    ""
-  ]},
-  {y = [
-    "foo",
-    "baz"
-  ]}
+  { x = [
+      "foo",
+      "bar"
+    ], a = [
+      ""
+    ] },
+  { y = [
+      "foo",
+      "baz"
+    ] }
 ]
 
 [b]
@@ -24,18 +24,18 @@ alist = [
   # Second attached comment
   'a'
 ]
-'aalist' = {c = "test", a = "another test"} # list comment
+'aalist' = { c = "test", a = "another test" } # list comment
 # Multilevel inline array
 aaalist = [
   [
-    {name = "Homer Simpson", town = "Springfield"}
+    { name = "Homer Simpson", town = "Springfield" }
   ],
   [
-    {name = "Bart Simpson", town = "Springfield"}
+    { name = "Bart Simpson", town = "Springfield" }
   ],
   # Weird block comment
   [
     # Another weird block comment
-    {name = "Lisa Simpson", town = "Springfield", a-test = "Did this sort?"} # Should get sorted
+    { name = "Lisa Simpson", town = "Springfield", a-test = "Did this sort?" } # Should get sorted
   ]
 ]

--- a/tests/examples/sorted/inline-no-comments-no-table-sort.toml
+++ b/tests/examples/sorted/inline-no-comments-no-table-sort.toml
@@ -1,16 +1,16 @@
 [b]
 aaalist = [
   [
-    {a-test = "Did this sort?", name = "Lisa Simpson", town = "Springfield"},
+    { a-test = "Did this sort?", name = "Lisa Simpson", town = "Springfield" },
   ],
   [
-    {name = "Bart Simpson", town = "Springfield"},
+    { name = "Bart Simpson", town = "Springfield" },
   ],
   [
-    {name = "Homer Simpson", town = "Springfield"},
+    { name = "Homer Simpson", town = "Springfield" },
   ],
 ]
-'aalist' = {a = "another test", c = "test"}
+'aalist' = { a = "another test", c = "test" }
 alist = [
   'a',
   'g',
@@ -22,14 +22,14 @@ z = []
 
 [a]
 test = [
-  {a = [
-    "",
-  ], x = [
-    "bar",
-    "foo",
-  ]},
-  {y = [
-    "baz",
-    "foo",
-  ]},
+  { a = [
+      "",
+    ], x = [
+      "bar",
+      "foo",
+    ] },
+  { y = [
+      "baz",
+      "foo",
+    ] },
 ]

--- a/tests/examples/sorted/inline.toml
+++ b/tests/examples/sorted/inline.toml
@@ -1,15 +1,15 @@
 [a]
 test = [
-  {a = [
-    ""
-  ], x = [
-    "bar",
-    "foo"
-  ]},
-  {y = [
-    "baz",
-    "foo"
-  ]}
+  { a = [
+      ""
+    ], x = [
+      "bar",
+      "foo"
+    ] },
+  { y = [
+      "baz",
+      "foo"
+    ] }
 ]
 
 [b]
@@ -18,16 +18,16 @@ aaalist = [
   # Weird block comment
   [
     # Another weird block comment
-    {a-test = "Did this sort?", name = "Lisa Simpson", town = "Springfield"}  # Should get sorted
+    { a-test = "Did this sort?", name = "Lisa Simpson", town = "Springfield" }  # Should get sorted
   ],
   [
-    {name = "Bart Simpson", town = "Springfield"}
+    { name = "Bart Simpson", town = "Springfield" }
   ],
   [
-    {name = "Homer Simpson", town = "Springfield"}
+    { name = "Homer Simpson", town = "Springfield" }
   ]
 ]
-'aalist' = {a = "another test", c = "test"}  # list comment
+'aalist' = { a = "another test", c = "test" }  # list comment
 alist = [
   # Multiline
   # Second attached comment

--- a/toml_sort/tomlsort.py
+++ b/toml_sort/tomlsort.py
@@ -471,7 +471,9 @@ class TomlSort:
         tomlsort_items = [
             TomlSortItem(
                 keys=keys + k,
-                value=self.sort_item(keys + k, v, indent_depth=indent_depth),
+                value=self.sort_item(
+                    keys + k, v, indent_depth=indent_depth + 1
+                ),
             )
             for k, v in item.value.body
             if not isinstance(v, Whitespace) and k is not None
@@ -482,11 +484,15 @@ class TomlSort:
         new_table = InlineTable(
             Container(parsed=True), trivia=item.trivia, new=True
         )
+        if tomlsort_items:
+            new_table.append(None, Whitespace(" "))
         for tomlsort_item in tomlsort_items:
             normalize_trivia(tomlsort_item.value, include_comments=False)
             new_table.append(
                 self.format_key(tomlsort_item.keys.base), tomlsort_item.value
             )
+        if tomlsort_items:
+            new_table.append(None, Whitespace(" "))
         new_table = normalize_trivia(
             new_table,
             include_comments=self.comment_config.inline,


### PR DESCRIPTION
I think this would be much cleaner. I would be happy to make this optional (my time permitting), if needed.

example from `tests/examples/sorted/inline-default.toml`:

```toml
'aalist' = { c = "test", a = "another test" } # list comment
```

multi-line example from `tests/examples/sorted/inline-default.toml`:

```toml
[a]
test = [
  { x = [
      "foo",
      "bar"
    ], a = [
      ""
    ] },
  { y = [
      "foo",
      "baz"
    ] }
]
```

NOTE that I would *personally* care the most about the single-line object case, no need for multi-line object formatting in my work at this point.