### PR TITLE
Only write to disk if file contents changed

### DIFF
--- a/toml_sort/cli.py
+++ b/toml_sort/cli.py
@@ -442,9 +442,11 @@ def cli(  # pylint: disable=too-many-branches,too-many-locals
             if original_toml != sorted_toml:
                 check_failures.append(filename)
         elif args.in_place:
-            write_file(filename, sorted_toml)
+            if original_toml != sorted_toml:
+                write_file(filename, sorted_toml)
         elif len(filenames_clean) == 1:
-            write_file(output_clean, sorted_toml)
+            if original_toml != sorted_toml:
+                write_file(output_clean, sorted_toml)
         else:
             printerr("Uncaught error. Please submit GitHub issue:")
             printerr("<https://github.com/pappasam/toml-sort/issues>")


### PR DESCRIPTION
`toml-sort` unconditionally writes to disk when operating in-place. Doing so can modify file metadata when the output hasn't changed.