### PR TITLE
Fix "first" sort for inline tables

### DIFF
--- a/tests/examples/from-toml-lang.toml
+++ b/tests/examples/from-toml-lang.toml
@@ -45,3 +45,7 @@ hosts = [
   name = "Nail"
   sku = 284758393
   color = "gray"
+
+[inline]
+# Test "first" sorting for inline tables
+c = { limit="<3.12", version ="4.12.2"}

--- a/tests/examples/sorted/from-toml-lang-first.toml
+++ b/tests/examples/sorted/from-toml-lang-first.toml
@@ -37,6 +37,10 @@ connection_max = 5000
 enabled = true # Comment after a boolean
 server = "192.168.1.1"
 
+[inline]
+# Test "first" sorting for inline tables
+c = {version = "4.12.2", limit = "<3.12"}
+
 [owner]
 name = "Tom Preston-Werner"
 dob = 1979-05-27T07:32:00Z # First class dates? Why not?

--- a/tests/examples/sorted/from-toml-lang-overrides.toml
+++ b/tests/examples/sorted/from-toml-lang-overrides.toml
@@ -16,6 +16,10 @@ enabled = true # Comment after a boolean
 ports = [8001, 8001, 8002]
 server = "192.168.1.1"
 
+[inline]
+# Test "first" sorting for inline tables
+c = {limit = "<3.12", version = "4.12.2"}
+
 [owner]
 bio = "GitHub Cofounder & CEO\nLikes tater tots and beer."
 dob = 1979-05-27T07:32:00Z # First class dates? Why not?

--- a/tests/examples/sorted/from-toml-lang.toml
+++ b/tests/examples/sorted/from-toml-lang.toml
@@ -16,6 +16,10 @@ ports = [8001, 8001, 8002]
 connection_max = 5000
 enabled = true # Comment after a boolean
 
+[inline]
+# Test "first" sorting for inline tables
+c = {limit = "<3.12", version = "4.12.2"}
+
 [owner]
 name = "Tom Preston-Werner"
 organization = "GitHub"

--- a/tests/test_toml_sort.py
+++ b/tests/test_toml_sort.py
@@ -111,6 +111,7 @@ def test_sort_toml_is_str() -> None:
                 "sort_config_overrides": {
                     "database": SortOverrideConfiguration(first=["ports"]),
                     "owner": SortOverrideConfiguration(first=["name", "dob"]),
+                    "inline.c": SortOverrideConfiguration(first=["version"]),
                 },
             },
         ),

--- a/toml_sort/tomlsort.py
+++ b/toml_sort/tomlsort.py
@@ -430,8 +430,9 @@ class TomlSort:
         """
 
         def sort_first(item: TomlSortItem) -> int:
-            if item.keys.base in sort_config.first:
-                return sort_config.first.index(item.keys.base.as_string())
+            for index, value in enumerate(sort_config.first):
+                if value == item.keys.base.key:
+                    return index
             return len(sort_config.first)
 
         items = sorted(items, key=self.key_sort_func)


### PR DESCRIPTION
Previously, sorting inline tables would throw a ValueError if the key in
the table had trailing spaces.

For example:

```toml
  [a]
  b = {c=1, d = 3}
```

Sorting a.b with "d" first would fail.

Removing the space would "pass":

```toml
  [a]
  b = {c=1, d=3}
```

However, when the table was written back out, rerunning toml-sort would
fail because the keys are written with surrounding spaces:

```toml
  [a]
  b = {c = 1, d = 3}
```

When commit https://github.com/pappasam/toml-sort/commit/9900c719e0e71db8158ed276277367356b79ea07 was introduced, the value used for the index
lookup in the list of "first" keys changed to be `Key.as_string()`.

The intent was probably to pass type checks as the list of keys are
strings and mypy complains when doing an index lookup that doesn't match
the typing of the list elements (str vs Key).

However, `as_string()` uses the "original" value of the key which
includes spaces and is subtlely different than the check performed
on the previous line that checked if the value was in the list.

Both the `in` keyword and the `list.index` method use the equality
operation to evaluate if a value is in a list.

The `Key` object defines the `__eq__` method that compares the internal
key value (which is stripped) to the other value. This is why the `in`
lookup succeeds but the `index` lookup fails.

Now, the lookup logic is simplified.

Instead of potentially searching the list of "first" keys twice, once
via `in` and once via `list.index`, iterate the list via `enumerate` to
keep track of the index and perform an explicit equality check against
`Key.key` which appeases mypy.