### PR TITLE
Remove py4 upper bound from pyproject.toml

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -421,5 +421,5 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.9"
-content-hash = "643a7b77e7f84223ea5c6cb1b34a4e812e0b04d95d9a693e159475edec9a9704"
+python-versions = ">=3.9"
+content-hash = "08973ace2e79b407209d28c433414c74313b11b188a90845fb8911d8714a0c50"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ include = ["README.md"]
 license = "MIT"
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = ">=3.9"
 tomlkit = ">=0.13.2"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
I could not figure out any good reason for this utility library to have a max cap of python below v4.
Please correct me and close this PR if I am mistaken in any way.

There is an overabundance of online discussions about the implications of capping the python version below 4, eg:
- https://github.com/pypa/packaging.python.org/pull/850

Replacing the poetry-style caret with the more classic semantic versioning greater-than-or-equal-to should suffice.
I've tested locally by poetry installing and building and I could not see any issue.