### PR TITLE
Handle dotted keys in inline tables correctly

### DIFF
--- a/tests/examples/gradle-version-catalog.toml
+++ b/tests/examples/gradle-version-catalog.toml
@@ -1,0 +1,7 @@
+[versions]
+fooVersion = "1.0.0"
+barVersion = "2.0.0"
+
+[libraries]
+fooLib = { module = "com.example:foo", version.ref = "fooVersion" }
+barLib = { module = "com.example:bar", version.ref = "barVersion" }

--- a/tests/examples/sorted/gradle-version-catalog.toml
+++ b/tests/examples/sorted/gradle-version-catalog.toml
@@ -1,0 +1,7 @@
+[versions]
+barVersion = "2.0.0"
+fooVersion = "1.0.0"
+
+[libraries]
+barLib = {module = "com.example:bar", version.ref = "barVersion"}
+fooLib = {module = "com.example:foo", version.ref = "fooVersion"}

--- a/tests/test_toml_sort.py
+++ b/tests/test_toml_sort.py
@@ -26,6 +26,15 @@ def test_sort_toml_is_str() -> None:
     "unsorted_fixture,sorted_fixture,args",
     [
         (
+            "gradle-version-catalog",
+            "gradle-version-catalog",
+            {
+                "sort_config": SortConfiguration(
+                    tables=False,
+                ),
+            },
+        ),
+        (
             "dotted-key",
             "dotted-key",
             {

--- a/toml_sort/tomlsort.py
+++ b/toml_sort/tomlsort.py
@@ -472,9 +472,11 @@ class TomlSort:
         """Format a key, removing any extra whitespace.
 
         Make sure that it will be formatted like: key = value with one space on
-        either side of the equal sign.
+        either side of the equal sign. For dotted keys, preserve the dotted format.
         """
-        key.sep = " = "
+        # Only set separator for non-dotted keys
+        if not key.is_dotted():
+            key.sep = " = "
         key._original = (  # pylint: disable=protected-access
             key.as_string().strip()
         )


### PR DESCRIPTION
Fixes an issue handling originally defined dotted keys by checking `tomlkit`'s `Key.is_dotted()` first. Adds a test case (verifying the Gradle version catalog issue is fixed) and does not break existing tests.

Closes https://github.com/pappasam/toml-sort/issues/90.